### PR TITLE
Don’t track if retailer_id or product_id is 0

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -42,9 +42,12 @@ exports = module.exports = function(app, starling) {
         badge_name: req.query.badge_name
       };
 
-      Future.task(function() {
-        starling.push('super_poller', { name: 'impression', body: body }, function(){});
-      }).detach();
+      // Healt check: /reevoomark/track/impression?product_id=0&retailer_id=0&...
+      if (body.product_id !== "0" && body.retailer_id !== "0") {
+        Future.task(function() {
+          starling.push('super_poller', { name: 'impression', body: body }, function(){});
+        }).detach();
+      }
 
       res.status(200).set(responseHeaders).send(imageResponse);
     }


### PR DESCRIPTION
Our varnish heart check is requesting:
/reevoomark/track/impression?product_id=0&retailer_id=0&badge_name=default&badge_type=product_reviews&badge_variant=default
